### PR TITLE
adjust: now refuse to launch app written in relative path to avoid hi…

### DIFF
--- a/misc/hooks.d/debFix.sh
+++ b/misc/hooks.d/debFix.sh
@@ -77,7 +77,7 @@ function choose_python(){
 
 exec_cmd_origin_path=$1
 
-if [[ -e ${exec_cmd_origin_path} ]]; then
+if [[ "${exec_cmd_origin_path}" = /* ]] && [[ -e ${exec_cmd_origin_path} ]]; then
 
     
 ##### 1. Check if the file is a script and is excutable and lack of shebang.(If not excutable, we should not let it run.)


### PR DESCRIPTION
…jack

Old design may let trojan app hijack command by creating an carefully designed script placed on AM's working directory.  Now  reject any request written in relative path